### PR TITLE
Fix action() by always calling gtm.dataOnSuccess()

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.userleap.com"
 documentation: "https://docs.userleap.com"
 versions:
+  - sha:
+    changeNotes: Correctly call data.gtmOnSuccess() at the end of action()
   - sha: 7503abd44e19559991a69479a6e54e16ad391cd0
     changeNotes: Added debugMode config
   - sha: 62c89085162c73fd3f36f951616f71add621212d

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 homepage: "https://www.userleap.com"
 documentation: "https://docs.userleap.com"
 versions:
-  - sha:
+  - sha: 8007eb383c9e2b2649229d7e88f2d6bc5bff7a4e
     changeNotes: Correctly call data.gtmOnSuccess() at the end of action()
   - sha: 7503abd44e19559991a69479a6e54e16ad391cd0
     changeNotes: Added debugMode config

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-___TERMS_OF_SERVICE___
+﻿___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -243,12 +243,12 @@ const action = () => {
     callInWindow('UserLeap._queue.push', ['setEmail', data.email]);
     logToConsole('Email', data.email);
   }
+  data.gtmOnSuccess();
 };
 
 const onSetupSuccess = () => {
   logToConsole('UserLeap: Script setup success.');
   action();
-  data.gtmOnSuccess();
 };
 
 const onSetupFailure = () => {
@@ -573,6 +573,6 @@ scenarios: []
 
 ___NOTES___
 
-Created on 9/3/2020, 5:38:33 PM
+Created on 4/23/2021, 2:43:34 PM
 
 


### PR DESCRIPTION
## Description
`gtm.dataOnSuccess()` was only being called on setup after `action()`. By moving it to the end of `action()` we ensure that `gtm.dataOnSuccess()` is always called
<!--- Describe your changes in detail -->

## Motivation and Context
The actions were correctly processing on our end but was incorrect for those waiting for the action to complete.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
GTM's "Run Code" functionality in the template creator
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Are Network Changes Included?

Does this change introduce new network connections to any UserLeap resources or third parties?

- [ ] Yes
- [x] No

If yes, have you taken every precaution to limit potential data exposure using best-practice encryption and secure connection protocols?

- [ ] Yes
- [ ] No

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- https://www.notion.so/userleap/Day-To-Day-Development-7682fdcdd7b147368ef430657fa187bd -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. <!--- https://app.gitbook.com/@userleap/s/docs-v1/ -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
